### PR TITLE
Def Headers Fixed

### DIFF
--- a/Defs/NeedDefs/Needs.xml
+++ b/Defs/NeedDefs/Needs.xml
@@ -5,7 +5,7 @@
     <defName>LeaderLevel</defName>
     <needClass>Nandonalt_ColonyLeadership.Need_LeaderLevel</needClass>
     <label>Leadership</label>
-    <description>The level of a leader is defined by what others think about the leader and his skillset.</description>
+    <description>The level of a leader is defined by what others think about the leader and their skillset.</description>
     <minIntelligence>Humanlike</minIntelligence>
     <colonistsOnly>true</colonistsOnly>
 	<neverOnPrisoner>true</neverOnPrisoner>


### PR DESCRIPTION
Updated def files headers. When defining a new definition, the base must always start with <Defs> label after A16. 